### PR TITLE
Add employee firing controls

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -210,6 +210,7 @@ function renderOwnedIndustries() {
               <!-- ② Controles de contratación -->
               <div class="hire-controls">
                 ${[5,10,50,100,500,1000].map(n=>`
+                  <button class="fire-btn" data-fire="${n}">-${n}</button>
                   <button class="hire-btn" data-hire="${n}">+${n}</button>
                 `).join('')}
               </div>
@@ -232,6 +233,15 @@ function renderOwnedIndustries() {
         const extra = parseInt(btn.dataset.hire, 10);
         industry.production.currentEmployees += extra;
         updateUI();               // refresca todos los números
+      });
+    });
+    card.querySelectorAll('.fire-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const remove = parseInt(btn.dataset.fire, 10);
+        const base   = industry.production.employees;
+        industry.production.currentEmployees =
+          Math.max(base, industry.production.currentEmployees - remove);
+        updateUI();
       });
     });
 


### PR DESCRIPTION
## Summary
- allow reducing staff on industry cards with new fire buttons
- prevent employee count going below base
- update salary costs whenever staff changes

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683f9a0e84f48332b103d9fa0390d7f5